### PR TITLE
Add event cards for upcoming and past events on home page

### DIFF
--- a/Visage.AppHost/Program.cs
+++ b/Visage.AppHost/Program.cs
@@ -3,7 +3,17 @@ using Microsoft.Extensions.Hosting;
 using Projects;
 using System.Globalization;
 
+
 var builder = DistributedApplication.CreateBuilder(args);
+
+#region EventAPI
+
+var EventAPI = builder.AddProject<Projects.Visage_Services_Eventing>("event-api")
+                 .WithExternalHttpEndpoints();
+
+#endregion
+
+
 
 #region web
 
@@ -13,15 +23,10 @@ string iam_clientid = builder.Configuration["Auth0:ClientId"] ?? throw new Excep
 var webapp = builder.AddProject<Projects.Visage_FrontEnd_Web>("frontendweb")
                                                         .WithEnvironment("Auth0__Domain", iam_domain)
                                                         .WithEnvironment("Auth0__ClientId", iam_clientid)
+                                                        .WithReference(EventAPI)
                                                         .WithExternalHttpEndpoints();
 
 #endregion
 
-#region api
-
-var api = builder.AddProject<Projects.Visage_Backend_Api>("backendapi")
-                 .WithExternalHttpEndpoints();
-
-#endregion
 
 builder.Build().Run();

--- a/Visage.AppHost/Program.cs
+++ b/Visage.AppHost/Program.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Hosting;
 using Projects;
 using System.Globalization;
 
-
 var builder = DistributedApplication.CreateBuilder(args);
 
 #region web
@@ -11,14 +10,18 @@ var builder = DistributedApplication.CreateBuilder(args);
 string iam_domain = builder.Configuration["Auth0:Domain"] ?? throw new Exception("Auth0 Domain required");
 string iam_clientid = builder.Configuration["Auth0:ClientId"] ?? throw new Exception("Auth0 ClientId required");
 
-
 var webapp = builder.AddProject<Projects.Visage_FrontEnd_Web>("frontendweb")
                                                         .WithEnvironment("Auth0__Domain", iam_domain)
                                                         .WithEnvironment("Auth0__ClientId", iam_clientid)
                                                         .WithExternalHttpEndpoints();
-                                                                    
 
 #endregion
 
+#region api
+
+var api = builder.AddProject<Projects.Visage_Backend_Api>("backendapi")
+                 .WithExternalHttpEndpoints();
+
+#endregion
 
 builder.Build().Run();

--- a/Visage.AppHost/Visage.AppHost.csproj
+++ b/Visage.AppHost/Visage.AppHost.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\services\Visage.Services.Eventing\Visage.Services.Eventing.csproj" />
     <ProjectReference Include="..\Visage.FrontEnd\Visage.FrontEnd.Web\Visage.FrontEnd.Web.csproj" />
   </ItemGroup>
 

--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Components/EventCard.razor
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Components/EventCard.razor
@@ -1,0 +1,60 @@
+@code {
+    [Parameter]
+    public string Title { get; set; }
+
+    [Parameter]
+    public string CoverPicture { get; set; }
+
+    [Parameter]
+    public DateTime Date { get; set; }
+
+    [Parameter]
+    public string Venue { get; set; }
+
+    [Parameter]
+    public int? AttendeesPercentage { get; set; }
+}
+
+<div class="event-card">
+    <img src="@CoverPicture" alt="@Title" class="event-cover" />
+    <div class="event-details">
+        <h3>@Title</h3>
+        <p>@Date.ToString("MMMM dd, yyyy")</p>
+        <p>@Venue</p>
+    </div>
+    @if (AttendeesPercentage.HasValue)
+    {
+        <div class="event-badge">
+            @AttendeesPercentage% Attended
+        </div>
+    }
+</div>
+
+<style>
+    .event-card {
+        border: 1px solid #ccc;
+        border-radius: 8px;
+        overflow: hidden;
+        margin-bottom: 16px;
+    }
+
+    .event-cover {
+        width: 100%;
+        height: 200px;
+        object-fit: cover;
+    }
+
+    .event-details {
+        padding: 16px;
+    }
+
+    .event-badge {
+        position: absolute;
+        top: 8px;
+        left: 8px;
+        background-color: #ff6347;
+        color: white;
+        padding: 4px 8px;
+        border-radius: 4px;
+    }
+</style>

--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Components/EventCard.razor
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Components/EventCard.razor
@@ -6,7 +6,7 @@
     public string CoverPicture { get; set; }
 
     [Parameter]
-    public DateTime Date { get; set; }
+    public DateOnly Date { get; set; }
 
     [Parameter]
     public string Venue { get; set; }
@@ -15,46 +15,15 @@
     public int? AttendeesPercentage { get; set; }
 }
 
-<div class="event-card">
-    <img src="@CoverPicture" alt="@Title" class="event-cover" />
-    <div class="event-details">
-        <h3>@Title</h3>
-        <p>@Date.ToString("MMMM dd, yyyy")</p>
-        <p>@Venue</p>
-    </div>
-    @if (AttendeesPercentage.HasValue)
-    {
-        <div class="event-badge">
-            @AttendeesPercentage% Attended
+<li class="card card-compact w-96 bg-base-100 shadow-xl hover:shadow-primary">
+    <figure class="relative w-full max-h-[240px]">
+        <img src="https://picsum.photos/400" alt="Event Cover picture of @Title" />
+    </figure>
+    <div class="card-body">
+        <h2 class="card-title justify-start">@Title</h2>
+        <p>@Date at @Venue</p>
+        <div class="card-actions">
+            <button class="btn btn-primary btn-block">Activate</button>
         </div>
-    }
-</div>
-
-<style>
-    .event-card {
-        border: 1px solid #ccc;
-        border-radius: 8px;
-        overflow: hidden;
-        margin-bottom: 16px;
-    }
-
-    .event-cover {
-        width: 100%;
-        height: 200px;
-        object-fit: cover;
-    }
-
-    .event-details {
-        padding: 16px;
-    }
-
-    .event-badge {
-        position: absolute;
-        top: 8px;
-        left: 8px;
-        background-color: #ff6347;
-        color: white;
-        padding: 4px 8px;
-        border-radius: 4px;
-    }
-</style>
+    </div>
+</li>

--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Layout/MainLayout.razor
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Layout/MainLayout.razor
@@ -4,11 +4,7 @@
     <NavHeader/>
 
     <main class="p-8">
-        <div class="top-row px-4">
-            <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
-        </div>
-
-        <article class="content px-4">
+        <article>
             @Body
         </article>
     </main>

--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Models/Event.cs
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Models/Event.cs
@@ -1,13 +1,45 @@
 using System;
+using System.ComponentModel.DataAnnotations;
+using StrictId;
 
-namespace Visage.FrontEnd.Shared.Models
+namespace Visage.FrontEnd.Shared.Models;
+
+
+public class Event
 {
-    public class Event
-    {
-        public string Title { get; set; }
-        public string CoverPicture { get; set; }
-        public DateTime Date { get; set; }
-        public string Venue { get; set; }
-        public int? AttendeesPercentage { get; set; }
-    }
+    [Required]
+    //[StringLength(50, ErrorMessage = "Event ID must be less than 50 characters.")]
+    public Id<Event> Id { get; init; }
+
+    [Required]
+    [StringLength(100, ErrorMessage = "Event Name must be less than 100 characters")]
+    public string Title { get; set; } = string.Empty;
+
+    public string? Type { get; set; }
+
+    public string? Description { get; set; }
+
+    [Required]
+    public DateOnly StartDate { get; set; }
+
+    [Required]
+    public TimeOnly StartTime { get; set; }
+
+    [Required]
+    public DateOnly EndDate { get; set; }
+
+    public TimeOnly EndTime { get; set; }
+
+    public string? Location { get; set; }
+
+
+
+    public string? CoverPictureLocation { get; set; }
+
+    public string? CoverPictureFileName { get; set; }
+
+
+    public int? AttendeesPercentage { get; set; }
+
 }
+

--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Models/Event.cs
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Models/Event.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Visage.FrontEnd.Shared.Models
+{
+    public class Event
+    {
+        public string Title { get; set; }
+        public string CoverPicture { get; set; }
+        public DateTime Date { get; set; }
+        public string Venue { get; set; }
+        public int? AttendeesPercentage { get; set; }
+    }
+}

--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Pages/Home.razor
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Pages/Home.razor
@@ -7,9 +7,42 @@
 
 <PageTitle>Home</PageTitle>
 
+<div class="flex justify-between mb-4">
+<h2 class="text-2xl font-extrabold mb-4">Upcoming Events</h2>
+<a class="link link-primary"> +Create new event</a>
+</div>
+@if (upcomingEvents == null || !upcomingEvents.Any())
+{
+    <p>No upcoming events. <a href="/create-event">Create a new event</a></p>
+}
+else
+{
+    <ul class="grid w-full gap-4 md:gap-6 sm:grid-cols-2 lg:grid-cols-3 xxl:grid-cols-4">
+
+    @foreach (var upcomingEvent in upcomingEvents)
+    {
+        <EventCard Title="@upcomingEvent.Title" CoverPicture="@upcomingEvent.CoverPictureFileName" Date="@upcomingEvent.StartDate" Venue="@upcomingEvent.Location" />
+    }
+    </ul>
+}
+
+<h2>Past Events</h2>
+@if (pastEvents == null || !pastEvents.Any())
+{
+    <p>No past events.</p>
+}
+else
+{
+    @foreach (var pastEvent in pastEvents)
+    {
+        <EventCard Title="@pastEvent.Title" CoverPicture="@pastEvent.CoverPictureFileName" Date="@pastEvent.StartDate" Venue="@pastEvent.Location" AttendeesPercentage="@pastEvent.AttendeesPercentage" />
+    }
+}
+
 <h1 class="text-3xl font-bold underline">
     Hello world! Its me!!!
 </h1>
+
 Welcome to your new app running on <em>@factor</em> using <em>@platform</em>.
 
 <button class="btn">Button</button>
@@ -20,37 +53,13 @@ Welcome to your new app running on <em>@factor</em> using <em>@platform</em>.
 <button class="btn btn-ghost">Ghost</button>
 <button class="btn btn-link">Link</button>
 
-<h2>Upcoming Events</h2>
-@if (upcomingEvents == null || !upcomingEvents.Any())
-{
-    <p>No upcoming events. <a href="/create-event">Create a new event</a></p>
-}
-else
-{
-    @foreach (var event in upcomingEvents)
-    {
-        <EventCard Title="@event.Title" CoverPicture="@event.CoverPicture" Date="@event.Date" Venue="@event.Venue" />
-    }
-}
 
-<h2>Past Events</h2>
-@if (pastEvents == null || !pastEvents.Any())
-{
-    <p>No past events.</p>
-}
-else
-{
-    @foreach (var event in pastEvents)
-    {
-        <EventCard Title="@event.Title" CoverPicture="@event.CoverPicture" Date="@event.Date" Venue="@event.Venue" AttendeesPercentage="@event.AttendeesPercentage" />
-    }
-}
 
 @code {
     private string factor => FormFactor.GetFormFactor();
     private string platform => FormFactor.GetPlatform();
-    private List<Event> upcomingEvents;
-    private List<Event> pastEvents;
+    private List<Event> upcomingEvents = null;
+    private List<Event> pastEvents = null;
 
     protected override async Task OnInitializedAsync()
     {

--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Pages/Home.razor
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Pages/Home.razor
@@ -1,6 +1,9 @@
-﻿@page "/"
+@page "/"
 @using Visage.FrontEnd.Shared.Services
+@using Visage.FrontEnd.Shared.Models
+@using Visage.FrontEnd.Shared.Components
 @inject IFormFactor FormFactor
+@inject IEventService EventService
 
 <PageTitle>Home</PageTitle>
 
@@ -17,7 +20,41 @@ Welcome to your new app running on <em>@factor</em> using <em>@platform</em>.
 <button class="btn btn-ghost">Ghost</button>
 <button class="btn btn-link">Link</button>
 
+<h2>Upcoming Events</h2>
+@if (upcomingEvents == null || !upcomingEvents.Any())
+{
+    <p>No upcoming events. <a href="/create-event">Create a new event</a></p>
+}
+else
+{
+    @foreach (var event in upcomingEvents)
+    {
+        <EventCard Title="@event.Title" CoverPicture="@event.CoverPicture" Date="@event.Date" Venue="@event.Venue" />
+    }
+}
+
+<h2>Past Events</h2>
+@if (pastEvents == null || !pastEvents.Any())
+{
+    <p>No past events.</p>
+}
+else
+{
+    @foreach (var event in pastEvents)
+    {
+        <EventCard Title="@event.Title" CoverPicture="@event.CoverPicture" Date="@event.Date" Venue="@event.Venue" AttendeesPercentage="@event.AttendeesPercentage" />
+    }
+}
+
 @code {
     private string factor => FormFactor.GetFormFactor();
     private string platform => FormFactor.GetPlatform();
+    private List<Event> upcomingEvents;
+    private List<Event> pastEvents;
+
+    protected override async Task OnInitializedAsync()
+    {
+        upcomingEvents = await EventService.GetUpcomingEvents();
+        pastEvents = await EventService.GetPastEvents();
+    }
 }

--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Services/EventService.cs
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Services/EventService.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Visage.FrontEnd.Shared.Models;
+
+namespace Visage.FrontEnd.Shared.Services
+{
+    public class EventService : IEventService
+    {
+        public async Task<List<Event>> GetUpcomingEvents()
+        {
+            // Fetch upcoming events from the backend
+            // This is a placeholder implementation
+            await Task.Delay(1000);
+            return new List<Event>
+            {
+                new Event
+                {
+                    Title = "Upcoming Event 1",
+                    CoverPicture = "cover1.jpg",
+                    Date = "2023-09-01",
+                    Venue = "Venue 1",
+                    AttendeesPercentage = 0
+                },
+                new Event
+                {
+                    Title = "Upcoming Event 2",
+                    CoverPicture = "cover2.jpg",
+                    Date = "2023-09-15",
+                    Venue = "Venue 2",
+                    AttendeesPercentage = 0
+                }
+            };
+        }
+
+        public async Task<List<Event>> GetPastEvents()
+        {
+            // Fetch past events from the backend
+            // This is a placeholder implementation
+            await Task.Delay(1000);
+            return new List<Event>
+            {
+                new Event
+                {
+                    Title = "Past Event 1",
+                    CoverPicture = "cover3.jpg",
+                    Date = "2023-08-01",
+                    Venue = "Venue 3",
+                    AttendeesPercentage = 75
+                },
+                new Event
+                {
+                    Title = "Past Event 2",
+                    CoverPicture = "cover4.jpg",
+                    Date = "2023-08-15",
+                    Venue = "Venue 4",
+                    AttendeesPercentage = 60
+                }
+            };
+        }
+    }
+}

--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Services/EventService.cs
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Services/EventService.cs
@@ -1,61 +1,26 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Visage.FrontEnd.Shared.Models;
+using System.Net.Http.Json;
 
 namespace Visage.FrontEnd.Shared.Services
 {
-    public class EventService : IEventService
+    public class EventService(HttpClient httpClient) : IEventService
     {
         public async Task<List<Event>> GetUpcomingEvents()
         {
             // Fetch upcoming events from the backend
             // This is a placeholder implementation
-            await Task.Delay(1000);
-            return new List<Event>
-            {
-                new Event
-                {
-                    Title = "Upcoming Event 1",
-                    CoverPicture = "cover1.jpg",
-                    Date = "2023-09-01",
-                    Venue = "Venue 1",
-                    AttendeesPercentage = 0
-                },
-                new Event
-                {
-                    Title = "Upcoming Event 2",
-                    CoverPicture = "cover2.jpg",
-                    Date = "2023-09-15",
-                    Venue = "Venue 2",
-                    AttendeesPercentage = 0
-                }
-            };
+            return await httpClient.GetFromJsonAsync<List<Event>>("/events") ?? [];
+
         }
 
         public async Task<List<Event>> GetPastEvents()
         {
             // Fetch past events from the backend
             // This is a placeholder implementation
-            await Task.Delay(1000);
-            return new List<Event>
-            {
-                new Event
-                {
-                    Title = "Past Event 1",
-                    CoverPicture = "cover3.jpg",
-                    Date = "2023-08-01",
-                    Venue = "Venue 3",
-                    AttendeesPercentage = 75
-                },
-                new Event
-                {
-                    Title = "Past Event 2",
-                    CoverPicture = "cover4.jpg",
-                    Date = "2023-08-15",
-                    Venue = "Venue 4",
-                    AttendeesPercentage = 60
-                }
-            };
+            return await httpClient.GetFromJsonAsync<List<Event>>("/events") ?? [];
+
         }
     }
 }

--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Services/IEventService.cs
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Services/IEventService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Visage.FrontEnd.Shared.Models;
+
+namespace Visage.FrontEnd.Shared.Services
+{
+    public interface IEventService
+    {
+        Task<List<Event>> GetUpcomingEvents();
+        Task<List<Event>> GetPastEvents();
+    }
+}

--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Visage.FrontEnd.Shared.csproj
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Visage.FrontEnd.Shared.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.0-rc.2.24474.3" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0-rc.2.24474.3" />
+    <PackageReference Include="StrictId" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/wwwroot/output.css
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/wwwroot/output.css
@@ -927,6 +927,76 @@ html {
   content: var(--tw-content);
 }
 
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--rounded-box, 1rem);
+}
+
+.card:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.card-body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  padding: var(--padding-card, 2rem);
+  gap: 0.5rem;
+}
+
+.card-body :where(p) {
+  flex-grow: 1;
+}
+
+.card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.card figure {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card.image-full {
+  display: grid;
+}
+
+.card.image-full:before {
+  position: relative;
+  content: "";
+  z-index: 10;
+  border-radius: var(--rounded-box, 1rem);
+  --tw-bg-opacity: 1;
+  background-color: var(--fallback-n,oklch(var(--n)/var(--tw-bg-opacity)));
+  opacity: 0.75;
+}
+
+.card.image-full:before,
+    .card.image-full > * {
+  grid-column-start: 1;
+  grid-row-start: 1;
+}
+
+.card.image-full > figure img {
+  height: 100%;
+  -o-object-fit: cover;
+     object-fit: cover;
+}
+
+.card.image-full > .card-body {
+  position: relative;
+  z-index: 20;
+  --tw-text-opacity: 1;
+  color: var(--fallback-nc,oklch(var(--nc)/var(--tw-text-opacity)));
+}
+
 .checkbox {
   flex-shrink: 0;
   --chkbg: var(--fallback-bc,oklch(var(--bc)/1));
@@ -1212,6 +1282,11 @@ html {
   .join *:first-child:not(:last-child) .dropdown .join-item {
   border-start-end-radius: inherit;
   border-end-end-radius: inherit;
+}
+
+.link {
+  cursor: pointer;
+  text-decoration-line: underline;
 }
 
 .menu {
@@ -1573,6 +1648,53 @@ html {
   }
 }
 
+.card :where(figure:first-child) {
+  overflow: hidden;
+  border-start-start-radius: inherit;
+  border-start-end-radius: inherit;
+  border-end-start-radius: unset;
+  border-end-end-radius: unset;
+}
+
+.card :where(figure:last-child) {
+  overflow: hidden;
+  border-start-start-radius: unset;
+  border-start-end-radius: unset;
+  border-end-start-radius: inherit;
+  border-end-end-radius: inherit;
+}
+
+.card:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.card.bordered {
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: var(--fallback-b2,oklch(var(--b2)/var(--tw-border-opacity)));
+}
+
+.card.compact .card-body {
+  padding: 1rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.card-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  font-weight: 600;
+}
+
+.card.image-full :where(figure) {
+  overflow: hidden;
+  border-radius: inherit;
+}
+
 .checkbox:focus {
   box-shadow: none;
 }
@@ -1707,6 +1829,29 @@ html {
 
 .join > :where(*:not(:first-child)):is(.btn) {
   margin-inline-start: calc(var(--border-btn) * -1);
+}
+
+.link-primary {
+  --tw-text-opacity: 1;
+  color: var(--fallback-p,oklch(var(--p)/var(--tw-text-opacity)));
+}
+
+@supports (color:color-mix(in oklab,black,black)) {
+  @media (hover:hover) {
+    .link-primary:hover {
+      color: color-mix(in oklab,var(--fallback-p,oklch(var(--p)/1)) 80%,black);
+    }
+  }
+}
+
+.link:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.link:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
 }
 
 .loading {
@@ -2008,6 +2153,10 @@ html {
       var(--handleoffsetcalculator) 0 0 3px var(--fallback-bc,oklch(var(--bc)/1)) inset;
 }
 
+.btn-block {
+  width: 100%;
+}
+
 .btn-circle:where(.btn-xs) {
   height: 1.5rem;
   width: 1.5rem;
@@ -2151,6 +2300,26 @@ html {
   right: 7%;
 }
 
+.card-compact .card-body {
+  padding: 1rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.card-compact .card-title {
+  margin-bottom: 0.25rem;
+}
+
+.card-normal .card-body {
+  padding: var(--padding-card, 2rem);
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+.card-normal .card-title {
+  margin-bottom: 0.75rem;
+}
+
 .join.join-vertical > :where(*:not(:first-child)):is(.btn) {
   margin-top: calc(var(--border-btn) * -1);
 }
@@ -2201,6 +2370,10 @@ html {
   position: static;
 }
 
+.relative {
+  position: relative;
+}
+
 .z-\[1\] {
   z-index: 1;
 }
@@ -2221,8 +2394,21 @@ html {
   grid-row-start: 1;
 }
 
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .mt-3 {
   margin-top: 0.75rem;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.flex {
+  display: flex;
 }
 
 .table {
@@ -2237,6 +2423,11 @@ html {
   display: none;
 }
 
+.size-full {
+  width: 100%;
+  height: 100%;
+}
+
 .h-5 {
   height: 1.25rem;
 }
@@ -2245,12 +2436,16 @@ html {
   height: 1.5rem;
 }
 
-.w-10 {
-  width: 2.5rem;
+.max-h-\[240px\] {
+  max-height: 240px;
 }
 
-.w-24 {
-  width: 6rem;
+.min-h-\[240px\] {
+  min-height: 240px;
+}
+
+.w-10 {
+  width: 2.5rem;
 }
 
 .w-5 {
@@ -2265,6 +2460,14 @@ html {
   width: 1.5rem;
 }
 
+.w-96 {
+  width: 24rem;
+}
+
+.w-full {
+  width: 100%;
+}
+
 .flex-1 {
   flex: 1 1 0%;
 }
@@ -2273,8 +2476,20 @@ html {
   cursor: pointer;
 }
 
+.flex-col {
+  flex-direction: column;
+}
+
 .place-items-center {
   place-items: center;
+}
+
+.justify-start {
+  justify-content: flex-start;
+}
+
+.justify-center {
+  justify-content: center;
 }
 
 .justify-between {
@@ -2283,6 +2498,10 @@ html {
 
 .gap-2 {
   gap: 0.5rem;
+}
+
+.gap-4 {
+  gap: 1rem;
 }
 
 .rounded-box {
@@ -2309,6 +2528,16 @@ html {
 
 .stroke-base-100 {
   stroke: var(--fallback-b1,oklch(var(--b1)/1));
+}
+
+.object-contain {
+  -o-object-fit: contain;
+     object-fit: contain;
+}
+
+.object-fill {
+  -o-object-fit: fill;
+     object-fit: fill;
 }
 
 .p-2 {
@@ -2339,8 +2568,17 @@ html {
   line-height: 1.75rem;
 }
 
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
 .font-bold {
   font-weight: 700;
+}
+
+.font-extrabold {
+  font-weight: 800;
 }
 
 .underline {
@@ -2353,9 +2591,47 @@ html {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.shadow-xl {
+  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.drop-shadow-md {
+  --tw-drop-shadow: drop-shadow(0 4px 3px rgb(0 0 0 / 0.07)) drop-shadow(0 2px 2px rgb(0 0 0 / 0.06));
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.hover\:shadow-primary:hover {
+  --tw-shadow-color: var(--fallback-p,oklch(var(--p)/1));
+  --tw-shadow: var(--tw-shadow-colored);
+}
+
+@media (min-width: 640px) {
+  .sm\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (min-width: 768px) {
   .md\:w-auto {
     width: auto;
+  }
+
+  .md\:flex-row {
+    flex-direction: row;
+  }
+
+  .md\:justify-center {
+    justify-content: center;
+  }
+
+  .md\:gap-4 {
+    gap: 1rem;
+  }
+
+  .md\:gap-6 {
+    gap: 1.5rem;
   }
 }
 
@@ -2366,5 +2642,9 @@ html {
 
   .lg\:hidden {
     display: none;
+  }
+
+  .lg\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }

--- a/Visage.FrontEnd/Visage.FrontEnd.Web/Program.cs
+++ b/Visage.FrontEnd/Visage.FrontEnd.Web/Program.cs
@@ -6,14 +6,13 @@ using Microsoft.IdentityModel.Tokens;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication;
 
-
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddAuth0WebAppAuthentication(options =>
-        {
-            builder.Configuration.Bind("Auth0", options);
-        });
-        
+{
+    builder.Configuration.Bind("Auth0", options);
+});
+
 builder.AddServiceDefaults();
 
 // Add services to the container.
@@ -24,10 +23,12 @@ builder.Services.AddRazorComponents()
 // Add device-specific services used by the Visage.FrontEnd.Shared project
 builder.Services.AddSingleton<IFormFactor, FormFactor>();
 
+// Register the IEventService and EventService in the dependency injection container
+builder.Services.AddSingleton<IEventService, EventService>();
+
 var app = builder.Build();
 
 app.MapDefaultEndpoints();
-
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/Visage.FrontEnd/Visage.FrontEnd.Web/Program.cs
+++ b/Visage.FrontEnd/Visage.FrontEnd.Web/Program.cs
@@ -24,7 +24,8 @@ builder.Services.AddRazorComponents()
 builder.Services.AddSingleton<IFormFactor, FormFactor>();
 
 // Register the IEventService and EventService in the dependency injection container
-builder.Services.AddSingleton<IEventService, EventService>();
+builder.Services.AddHttpClient<IEventService, EventService>( client =>
+                client.BaseAddress = new("https+http://event-api"));
 
 var app = builder.Build();
 

--- a/Visage.FrontEnd/Visage.FrontEnd.Web/Visage.FrontEnd.Web.csproj
+++ b/Visage.FrontEnd/Visage.FrontEnd.Web/Visage.FrontEnd.Web.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\Visage.ServiceDefaults\Visage.ServiceDefaults.csproj" />
     <ProjectReference Include="..\Visage.FrontEnd.Web.Client\Visage.FrontEnd.Web.Client.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.0-rc.2.24474.3" />
+    <ProjectReference Include="..\..\Visage.AppHost\Visage.AppHost.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Visage.sln
+++ b/Visage.sln
@@ -9,14 +9,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WebApps", "WebApps", "{6722
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Services", "Services", "{F35A7FEA-7C11-474A-82E5-549966D4DF47}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Checkins.API", "Checkins.API\Checkins.API.csproj", "{05A7C010-C93B-4881-B6A3-510DB16E8988}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Checkins.API", "Checkins.API", "{87B5968D-1DC0-473A-9B88-10B1810E936D}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{91883382-668D-4AA8-A54A-FD8425A716D6}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Checkins.UnitTests", "Checkins.UnitTests\Checkins.UnitTests.csproj", "{61947BEF-FD71-4D46-868F-10F510FA65CD}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Visage.AppHost", "Visage.AppHost\Visage.AppHost.csproj", "{7D4E65D5-2F1E-4CC8-8A5D-DDE184FEAB79}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Visage.ServiceDefaults", "Visage.ServiceDefaults\Visage.ServiceDefaults.csproj", "{32385DD2-C85E-434B-82DB-719574DCEC38}"
@@ -29,20 +21,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Visage.FrontEnd.Web", "Visa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Visage.FrontEnd.Web.Client", "Visage.FrontEnd\Visage.FrontEnd.Web.Client\Visage.FrontEnd.Web.Client.csproj", "{20EE1EC7-CF2B-4249-AA1C-697BCBE39F7F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Visage.Services.Eventing", "services\Visage.Services.Eventing\Visage.Services.Eventing.csproj", "{E560F5FB-936F-4D94-AD5C-F16200DF4C02}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{05A7C010-C93B-4881-B6A3-510DB16E8988}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{05A7C010-C93B-4881-B6A3-510DB16E8988}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{05A7C010-C93B-4881-B6A3-510DB16E8988}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{05A7C010-C93B-4881-B6A3-510DB16E8988}.Release|Any CPU.Build.0 = Release|Any CPU
-		{61947BEF-FD71-4D46-868F-10F510FA65CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{61947BEF-FD71-4D46-868F-10F510FA65CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{61947BEF-FD71-4D46-868F-10F510FA65CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{61947BEF-FD71-4D46-868F-10F510FA65CD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7D4E65D5-2F1E-4CC8-8A5D-DDE184FEAB79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7D4E65D5-2F1E-4CC8-8A5D-DDE184FEAB79}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7D4E65D5-2F1E-4CC8-8A5D-DDE184FEAB79}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -69,15 +55,16 @@ Global
 		{20EE1EC7-CF2B-4249-AA1C-697BCBE39F7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{20EE1EC7-CF2B-4249-AA1C-697BCBE39F7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{20EE1EC7-CF2B-4249-AA1C-697BCBE39F7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E560F5FB-936F-4D94-AD5C-F16200DF4C02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E560F5FB-936F-4D94-AD5C-F16200DF4C02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E560F5FB-936F-4D94-AD5C-F16200DF4C02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E560F5FB-936F-4D94-AD5C-F16200DF4C02}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{05A7C010-C93B-4881-B6A3-510DB16E8988} = {87B5968D-1DC0-473A-9B88-10B1810E936D}
-		{87B5968D-1DC0-473A-9B88-10B1810E936D} = {F35A7FEA-7C11-474A-82E5-549966D4DF47}
-		{91883382-668D-4AA8-A54A-FD8425A716D6} = {87B5968D-1DC0-473A-9B88-10B1810E936D}
-		{61947BEF-FD71-4D46-868F-10F510FA65CD} = {91883382-668D-4AA8-A54A-FD8425A716D6}
+		{E560F5FB-936F-4D94-AD5C-F16200DF4C02} = {F35A7FEA-7C11-474A-82E5-549966D4DF47}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6DFD8D43-B55A-46A9-8FC2-22BACFF0AE1F}

--- a/services/Visage.Services.Eventing/EventDB.cs
+++ b/services/Visage.Services.Eventing/EventDB.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore;
+using StrictId.EFCore;
+using Visage.FrontEnd.Shared.Models;
+
+public class EventDB: DbContext
+{
+    public EventDB(DbContextOptions<EventDB> options) : base(options)
+    {
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder builder)
+    {
+        builder.ConfigureStrictId();
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Event>().Property(e => e.Id)
+                                        .ValueGeneratedOnAdd()
+                                        .HasStrictIdValueGenerator();
+    }
+
+    public DbSet<Event> Events => Set<Event>();
+}
+
+

--- a/services/Visage.Services.Eventing/Program.cs
+++ b/services/Visage.Services.Eventing/Program.cs
@@ -1,0 +1,80 @@
+using Microsoft.EntityFrameworkCore;
+using Scalar.AspNetCore;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Visage.FrontEnd.Shared.Models;
+using Microsoft.AspNetCore.Mvc;
+
+
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add service defaults & Aspire components.
+builder.AddServiceDefaults();
+
+builder.Services.AddDbContext<EventDB>(opt => opt.UseInMemoryDatabase("EventList"));
+builder.Services.AddDatabaseDeveloperPageExceptionFilter();
+
+
+
+// Add services to the container.
+// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+    app.MapScalarApiReference(options =>
+            {
+                options.WithTitle("Visage API")
+                       .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient);
+            }
+    );
+}
+
+app.UseHttpsRedirection();
+
+var events = app.MapGroup("/events");
+
+events.MapGet("/", GetAllEvents);
+
+events.MapPost("/", ScheduleEvent)
+    .WithName("Schedule Event")
+    .WithOpenApi();
+
+app.Run();
+
+
+static async Task<IResult> GetAllEvents(EventDB db)
+{
+    return TypedResults.Ok(await db.Events.ToListAsync());
+}
+
+static async Task<Results<BadRequest<String>, Created<Event>>> ScheduleEvent([FromBody]Event EventDetails, EventDB db)
+{
+    try
+    {
+        db.Events.Add(EventDetails);
+        await db.SaveChangesAsync();
+
+        // Assuming the Event object has an Id property that is set upon saving (e.g., auto-incremented by the database)
+        // Construct the URI where the newly created event can be accessed
+        // For example, if you have an endpoint to get an event by its Id
+        string newEventUri = $"/events/{EventDetails.Id}";
+
+        // Return a Created result with the URI and the event object
+        return TypedResults.Created(newEventUri, EventDetails);
+    }
+    catch (Exception ex)
+    {
+        return TypedResults.BadRequest(ex.Message);
+    }
+}
+
+
+
+
+
+

--- a/services/Visage.Services.Eventing/Visage.Services.Eventing.csproj
+++ b/services/Visage.Services.Eventing/Visage.Services.Eventing.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.0-rc.2.24474.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rc.2.24474.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
+    <PackageReference Include="Scalar.AspNetCore" Version="1.2.*" />
+    <PackageReference Include="StrictId.EFCore" Version="1.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Visage.FrontEnd\Visage.FrontEnd.Shared\Visage.FrontEnd.Shared.csproj" />
+    <ProjectReference Include="..\..\Visage.ServiceDefaults\Visage.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/services/Visage.Services.Eventing/Visage.Services.Eventing.http
+++ b/services/Visage.Services.Eventing/Visage.Services.Eventing.http
@@ -1,0 +1,18 @@
+@Visage.Services.Eventing_HostAddress = https://localhost:7156
+
+GET {{Visage.Services.Eventing_HostAddress}}/events
+Accept: application/json
+
+###
+
+POST {{Visage.Services.Eventing_HostAddress}}/events
+Content-Type: application/json
+
+{  
+  
+  "title": ".NET Conf 2024 - Recap",
+  "startDate":"2024-11-28",
+  "startTime": "15:00",
+  "endDate": "2024-11-28",
+  "location": "Microsoft Mumbai"
+}

--- a/services/Visage.Services.Eventing/appsettings.json
+++ b/services/Visage.Services.Eventing/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Fixes #93

Add event cards for upcoming and past events on the home page.

* Modify `Home.razor` to include sections for upcoming and past events, displaying event cards with title, cover picture, date, and venue.
* Create `EventCard.razor` component to represent individual event cards with properties for title, cover picture, date, venue, and attendees percentage.
* Add `IEventService.cs` interface to define methods for fetching upcoming and past events.
* Implement `EventService.cs` to fetch events from the backend.
* Add `Event.cs` model class to represent event data.
* Update `Program.cs` in `Visage.FrontEnd.Web` to register `IEventService` and `EventService` in the dependency injection container.
* Modify `Program.cs` in `Visage.AppHost` to include Minimal Backend API as part of the host model.
* Update `Visage.FrontEnd.Web.csproj` to add reference to `Visage.AppHost` project.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HackerspaceMumbai/Visage/issues/93?shareId=e9434319-88bf-42df-a167-733a819840d5).