### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/services/CloudinaryImageSigning/app.js
+++ b/services/CloudinaryImageSigning/app.js
@@ -21,7 +21,7 @@ const config = {
   cacheAddress: process.env['ConnectionStrings__cache'] ?? '',
   apiServer: process.env['services__weatherapi__https__0'] ?? process.env['services__weatherapi__http__0']
 };
-console.log(`config: ${JSON.stringify(config)}`);
+console.log(`Configuration loaded. Environment: ${config.environment}, HTTP Port: ${config.httpPort}, HTTPS Port: ${config.httpsPort}`);
 
 
 // Setup HTTPS options


### PR DESCRIPTION
Potential fix for [https://github.com/HackerspaceMumbai/Visage/security/code-scanning/8](https://github.com/HackerspaceMumbai/Visage/security/code-scanning/8)

To fix the problem, we should avoid logging sensitive information contained in the `config` object. Instead, we can log only non-sensitive parts of the configuration or use a placeholder message indicating that the configuration has been loaded without exposing its contents.

- Identify and exclude sensitive information from the `config` object before logging.
- Replace the logging statement with a safer alternative that does not expose sensitive data.
- Ensure that the fix is applied to the relevant lines in the file `services/CloudinaryImageSigning/app.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
