### PR TITLE
fix: :bug: Newly scheduled events will appear in either upcoming or p…

### DIFF
--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Services/EventService.cs
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Services/EventService.cs
@@ -13,17 +13,15 @@ namespace Visage.FrontEnd.Shared.Services
         public async Task<List<Event>> GetUpcomingEvents()
         {
             // Fetch upcoming events from the backend
-            // This is a placeholder implementation
-            return await httpClient.GetFromJsonAsync<List<Event>>("/events") ?? [];
-
+            return await httpClient.GetFromJsonAsync<List<Event>>("/events/upcoming")
+                   ?? new List<Event>();
         }
 
         public async Task<List<Event>> GetPastEvents()
         {
             // Fetch past events from the backend
-            // This is a placeholder implementation
-            return await httpClient.GetFromJsonAsync<List<Event>>("/events") ?? [];
-
+            return await httpClient.GetFromJsonAsync<List<Event>>("/events/past")
+                   ?? new List<Event>();
         }
 
         public async Task ScheduleEvent(Event newEvent)


### PR DESCRIPTION
…ast but not in both

Created two dedicated endpoints: one for upcoming, and the other for  past

Fixes 118



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced separate views for upcoming and past events, allowing users to easily access events based on their date.
- **Bug Fixes**
  - Improved accuracy of event listings by fetching upcoming and past events from dedicated sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->