### PR TITLE
fix: :bug: Update event cover picture handling and deprecate old properties

### DIFF
--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Components/Event/EventCard.razor
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Components/Event/EventCard.razor
@@ -17,7 +17,7 @@
 
 <li class="card card-compact w-96 bg-base-100 shadow-xl hover:shadow-primary">
     <figure class="relative w-full max-h-[240px]">
-        <img src="https://picsum.photos/400" alt="Event Cover picture of @Title" />
+        <img src="@(string.IsNullOrWhiteSpace(CoverPicture) ? "https://picsum.photos/400" : CoverPicture)" alt="Event Cover picture of @Title" />
     </figure>
     <div class="card-body">
         <h2 class="card-title justify-start">@Title</h2>

--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Models/Event.cs
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Models/Event.cs
@@ -32,8 +32,12 @@ public class Event
 
     public string? Location { get; set; }
 
+
+    // Deprecated: Use CoverPicture for the Cloudinary image URL
+    [Obsolete("Use CoverPicture property instead.")]
     public string? CoverPictureLocation { get; set; }
 
+    [Obsolete("Use CoverPicture property instead.")]
     public string? CoverPictureFileName { get; set; }
 
     public int? AttendeesPercentage { get; set; }

--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Pages/Home.razor
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Pages/Home.razor
@@ -33,7 +33,7 @@ else
 
         @foreach (var upcomingEvent in upcomingEvents)
         {
-            <EventCard Title="@upcomingEvent.Title" CoverPicture="@upcomingEvent.CoverPictureFileName" Date="@upcomingEvent.StartDate" Venue="@upcomingEvent.Location" />
+            <EventCard Title="@upcomingEvent.Title" CoverPicture="@upcomingEvent.CoverPicture" Date="@upcomingEvent.StartDate" Venue="@upcomingEvent.Location" />
         }
     </ul>
 }
@@ -47,7 +47,7 @@ else
 {
     @foreach (var pastEvent in pastEvents)
     {
-        <EventCard Title="@pastEvent.Title" CoverPicture="@pastEvent.CoverPictureFileName" Date="@pastEvent.StartDate" Venue="@pastEvent.Location" AttendeesPercentage="@pastEvent.AttendeesPercentage" />
+        <EventCard Title="@pastEvent.Title" CoverPicture="@pastEvent.CoverPicture" Date="@pastEvent.StartDate" Venue="@pastEvent.Location" AttendeesPercentage="@pastEvent.AttendeesPercentage" />
     }
 }
 

--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Pages/ScheduleEvent.razor
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Pages/ScheduleEvent.razor
@@ -254,9 +254,18 @@
                         {
                             if (response.IsSuccessStatusCode)
                             {
-                                var cloudinaryUrl = await response.Content.ReadAsStringAsync();
-                                newEvent!.CoverPictureLocation = cloudinaryUrl;
-                                uploadStatusMessage = "Image uploaded successfully!";
+                                var cloudinaryJson = await response.Content.ReadAsStringAsync();
+                                string? url = null;
+                                try
+                                {
+                                    url = System.Text.Json.JsonDocument.Parse(cloudinaryJson).RootElement.GetProperty("url").GetString();
+                                }
+                                catch (Exception ex)
+                                {
+                                    Console.WriteLine($"Failed to parse Cloudinary response: {ex.Message}\nResponse: {cloudinaryJson}");
+                                }
+                                newEvent!.CoverPicture = url;
+                                uploadStatusMessage = url != null ? "Image uploaded successfully!" : "Image uploaded, but URL could not be parsed.";
                             }
                             else
                             {


### PR DESCRIPTION
Fixes Event Card not displaying the event picture #124


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Event cards now display a custom cover image if available; otherwise, a default placeholder image is shown.
- **Bug Fixes**
  - Improved handling of image uploads, ensuring the correct image URL is extracted and displayed after upload.
- **Chores**
  - Updated event properties to encourage use of the new cover image property and marked old image properties as obsolete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->