### PR TITLE
bug:fix:Refactor Registrant model by removing redundant Address property and renaming AddressLine1

### DIFF
--- a/Visage.FrontEnd/Visage.FrontEnd.Shared/Models/Registrant.cs
+++ b/Visage.FrontEnd/Visage.FrontEnd.Shared/Models/Registrant.cs
@@ -18,9 +18,7 @@ public class Registrant
     [Required]
     public string LastName { get; set; } = string.Empty;
 
-    [Required]
-    public string Address { get; set; } = string.Empty;
-
+    
     [Required]
     public string AddressLine1 { get; set; } = string.Empty;
 


### PR DESCRIPTION
Signed-off-by: Augustine Correa <augcor@gmail.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated address entry to use a more specific "Address Line 1" field instead of a single "Address" field on registration forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->