### PR TITLE
143 streamlined urls in aspire dashboard

### DIFF
--- a/Visage.AppHost/Program.cs
+++ b/Visage.AppHost/Program.cs
@@ -9,10 +9,10 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 #region Auth0Configuration
 
-var iamDomain = builder.AddParameter("auth0-domain", secret: false);
-var iamClientId = builder.AddParameter("auth0-clientid", secret: false);
+var iamDomain = builder.AddParameter("auth0-domain");
+var iamClientId = builder.AddParameter("auth0-clientid");
 var iamClientSecret = builder.AddParameter("auth0-clientsecret", secret: true);
-var iamAudience = builder.AddParameter("auth0-audience", secret: false);
+var iamAudience = builder.AddParameter("auth0-audience"); //For API access
 
 #endregion
 
@@ -24,19 +24,20 @@ var VisageSQL = builder.AddConnectionString("visagesql");
 
 var clarityProjectId = builder.AddParameter("clarity-projectid", secret: false);
 
-// Validate the parameter value at runtime
-var clarityProjectIdValue = builder.Configuration["clarity-projectid"];
-if (string.IsNullOrWhiteSpace(clarityProjectIdValue))
-{
-    throw new Exception("Clarity Project ID required");
-}
-
 #endregion
 
 #region EventAPI
 
 var EventAPI = builder.AddProject<Projects.Visage_Services_Eventing>("event-api")
-                 .WithExternalHttpEndpoints();
+                                            .WithUrlForEndpoint("http",
+                               url => url.DisplayLocation = UrlDisplayLocation.DetailsOnly) // Hide the plain-HTTP link from the Resources grid
+                                            .WithUrlForEndpoint("https", url =>
+                                            {
+                                                url.DisplayText = "Event API Scalar OpenAPI";
+                                                url.Url += "/scalar/v1";
+                                            }); 
+               
+                 
 
 #endregion
 

--- a/Visage.FrontEnd/Visage.FrontEnd.Web/Services/ClarityConfig.cs
+++ b/Visage.FrontEnd/Visage.FrontEnd.Web/Services/ClarityConfig.cs
@@ -1,4 +1,4 @@
-namespace Visage.FrontEnd.Web;
+namespace Visage.FrontEnd.Web.Services;
 
 public class ClarityConfig
 {


### PR DESCRIPTION
This pull request makes a small change to the `Visage.AppHost/Program.cs` file, removing the `secret: false` parameter from several `AddParameter` method calls. This simplifies the code by relying on the default behavior for non-secret parameters.

Auth0 configuration updates:

* Removed `secret: false` from the `AddParameter` calls for `auth0-domain`, `auth0-clientid`, and `auth0-audience`, simplifying the parameter definitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated parameter configuration for authentication settings to use default secrecy behavior.
  - Added a comment clarifying the use of the "auth0-audience" parameter for API access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->